### PR TITLE
fix: use `go install` isntead of `go get` for `make deps`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 all: gen fmt test install
 
 deps:
-	go get -u golang.org/x/tools/cmd/goimports
-	go get -u golang.org/x/lint/golint
+	go install golang.org/x/tools/cmd/goimports@latest
+	go install golang.org/x/lint/golint@latest
 
 gen:
 	go generate ./...


### PR DESCRIPTION
Not sure if this is required, however I had to do this to make it work on my local machine (I'm not a go expert so please validate before merging).

Version used
```bash
go version go1.23.4 darwin/arm64
```